### PR TITLE
General: Make use of Qt 5's signal/slot connection syntax

### DIFF
--- a/DownloadManager.cpp
+++ b/DownloadManager.cpp
@@ -54,10 +54,10 @@ void DownloadManager::fetchIndex() {
   QString track = QSettings().value("update_track").toString();
   QString url = Domain + track + '/' + CurPlatformString + '/' + Index;
   m_indexInProgress = m_netManager.get(QNetworkRequest(url));
-  connect(m_indexInProgress, SIGNAL(finished()), this, SLOT(indexFinished()));
-  connect(m_indexInProgress, SIGNAL(error(QNetworkReply::NetworkError)), this,
-          SLOT(indexError(QNetworkReply::NetworkError)));
-  connect(m_indexInProgress, SIGNAL(encrypted()), this, SLOT(indexValidateCert()));
+  connect(m_indexInProgress, &QNetworkReply::finished, this, &DownloadManager::indexFinished);
+  connect(m_indexInProgress, qOverload<QNetworkReply::NetworkError>(&QNetworkReply::error), this,
+          &DownloadManager::indexError);
+  connect(m_indexInProgress, &QNetworkReply::encrypted, this, &DownloadManager::indexValidateCert);
 }
 
 void DownloadManager::fetchBinary(const QString& str, const QString& outPath) {
@@ -67,15 +67,14 @@ void DownloadManager::fetchBinary(const QString& str, const QString& outPath) {
   resetError();
   m_outPath = outPath;
 
-  QString track = QSettings().value("update_track").toString();
-  QString url = Domain + track + '/' + CurPlatformString + '/' + str;
+  const QString track = QSettings().value("update_track").toString();
+  const QString url = Domain + track + '/' + CurPlatformString + '/' + str;
   m_binaryInProgress = m_netManager.get(QNetworkRequest(url));
-  connect(m_binaryInProgress, SIGNAL(finished()), this, SLOT(binaryFinished()));
-  connect(m_binaryInProgress, SIGNAL(error(QNetworkReply::NetworkError)), this,
-          SLOT(binaryError(QNetworkReply::NetworkError)));
-  connect(m_binaryInProgress, SIGNAL(encrypted()), this, SLOT(binaryValidateCert()));
-  connect(m_binaryInProgress, SIGNAL(downloadProgress(qint64, qint64)), this,
-          SLOT(binaryDownloadProgress(qint64, qint64)));
+  connect(m_binaryInProgress, &QNetworkReply::finished, this, &DownloadManager::binaryFinished);
+  connect(m_binaryInProgress, qOverload<QNetworkReply::NetworkError>(&QNetworkReply::error), this,
+          &DownloadManager::binaryError);
+  connect(m_binaryInProgress, &QNetworkReply::encrypted, this, &DownloadManager::binaryValidateCert);
+  connect(m_binaryInProgress, &QNetworkReply::downloadProgress, this, &DownloadManager::binaryDownloadProgress);
 
   if (m_progBar) {
     m_progBar->setEnabled(true);

--- a/LaunchMenu.cpp
+++ b/LaunchMenu.cpp
@@ -46,7 +46,7 @@ LaunchMenu::LaunchMenu(hecl::CVarCommons& commons, QWidget* parent)
   addMenu(&m_msaaMenu)->setToolTip(m_commons.m_drawSamples->rawHelp().data());
   addMenu(&m_anisoMenu)->setToolTip(m_commons.m_texAnisotropy->rawHelp().data());
   QAction* argumentEditor = addAction("Edit Runtime Arguments");
-  connect(argumentEditor, SIGNAL(triggered()), this, SLOT(editRuntimeArgs()));
+  connect(argumentEditor, &QAction::triggered, this, &LaunchMenu::editRuntimeArgs);
   initDeepColor();
   initDeveloperMode();
   initCheats();
@@ -54,7 +54,7 @@ LaunchMenu::LaunchMenu(hecl::CVarCommons& commons, QWidget* parent)
 
 void LaunchMenu::initApiAction(const QString& action) {
   QAction* act = m_apiGroup.addAction(action);
-  connect(act, SIGNAL(triggered()), this, SLOT(apiTriggered()));
+  connect(act, &QAction::triggered, this, &LaunchMenu::apiTriggered);
   act->setCheckable(true);
   if (!action.compare(QString::fromStdString(m_commons.getGraphicsApi()), Qt::CaseInsensitive))
     act->setChecked(true);
@@ -62,7 +62,7 @@ void LaunchMenu::initApiAction(const QString& action) {
 
 void LaunchMenu::initMsaaAction(const QString& action) {
   QAction* act = m_msaaGroup.addAction(action);
-  connect(act, SIGNAL(triggered()), this, SLOT(msaaTriggered()));
+  connect(act, &QAction::triggered, this, &LaunchMenu::msaaTriggered);
   act->setCheckable(true);
   if (!action.compare(QString::number(m_commons.getSamples()), Qt::CaseInsensitive))
     act->setChecked(true);
@@ -70,7 +70,7 @@ void LaunchMenu::initMsaaAction(const QString& action) {
 
 void LaunchMenu::initAnisoAction(const QString& action) {
   QAction* act = m_anisoGroup.addAction(action);
-  connect(act, SIGNAL(triggered()), this, SLOT(anisoTriggered()));
+  connect(act, &QAction::triggered, this, &LaunchMenu::anisoTriggered);
   act->setCheckable(true);
   if (!action.compare(QString::number(m_commons.getAnisotropy()), Qt::CaseInsensitive))
     act->setChecked(true);
@@ -81,7 +81,7 @@ void LaunchMenu::initDeepColor() {
   act->setToolTip(m_commons.m_deepColor->rawHelp().data());
   act->setCheckable(true);
   act->setChecked(m_commons.getDeepColor());
-  connect(act, SIGNAL(triggered()), this, SLOT(deepColorTriggered()));
+  connect(act, &QAction::triggered, this, &LaunchMenu::deepColorTriggered);
 }
 
 void LaunchMenu::initDeveloperMode() {
@@ -89,7 +89,7 @@ void LaunchMenu::initDeveloperMode() {
   act->setToolTip(hecl::com_developer->rawHelp().data());
   act->setCheckable(true);
   act->setChecked(hecl::com_developer->toBoolean());
-  connect(act, SIGNAL(triggered()), this, SLOT(developerModeTriggered()));
+  connect(act, &QAction::triggered, this, &LaunchMenu::developerModeTriggered);
 }
 
 void LaunchMenu::initCheats() {
@@ -97,7 +97,7 @@ void LaunchMenu::initCheats() {
   act->setToolTip(hecl::com_enableCheats->rawHelp().data());
   act->setCheckable(true);
   act->setChecked(hecl::com_enableCheats->toBoolean());
-  connect(act, SIGNAL(triggered()), this, SLOT(cheatsTriggered()));
+  connect(act, &QAction::triggered, this, &LaunchMenu::cheatsTriggered);
 }
 
 void LaunchMenu::apiTriggered() {

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -88,12 +88,13 @@ MainWindow::MainWindow(QWidget* parent)
   QPalette pal = m_updateURDEButton->palette();
   pal.setColor(QPalette::Button, QColor(53, 53, 72));
   m_updateURDEButton->setPalette(pal);
-  connect(m_updateURDEButton, SIGNAL(clicked()), this, SLOT(onUpdateURDEPressed()));
+  connect(m_updateURDEButton, &QPushButton::clicked, this, &MainWindow::onUpdateURDEPressed);
   qDebug() << "Stored track " << m_settings.value("update_track");
-  int index = skUpdateTracks.indexOf(m_settings.value("update_track").toString());
+  const int index = skUpdateTracks.indexOf(m_settings.value("update_track").toString());
   m_ui->devTrackWarning->setVisible(index == 1);
   m_ui->updateTrackComboBox->setCurrentIndex(index);
-  connect(m_ui->updateTrackComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(onUpdateTrackChanged(int)));
+  connect(m_ui->updateTrackComboBox, qOverload<int>(&QComboBox::currentIndexChanged), this,
+          &MainWindow::onUpdateTrackChanged);
 
   m_dlManager.connectWidgets(m_ui->downloadProgressBar, m_ui->downloadErrorLabel,
                              std::bind(&MainWindow::onIndexDownloaded, this, std::placeholders::_1),
@@ -128,8 +129,8 @@ void MainWindow::onExtract() {
   env.insert("TERM", "xterm-color");
   env.insert("ConEmuANSI", "ON");
   m_heclProc.setProcessEnvironment(env);
-  disconnect(&m_heclProc, SIGNAL(finished(int)), nullptr, nullptr);
-  connect(&m_heclProc, SIGNAL(finished(int)), this, SLOT(onExtractFinished(int)));
+  disconnect(&m_heclProc, qOverload<int>(&QProcess::finished), nullptr, nullptr);
+  connect(&m_heclProc, qOverload<int>(&QProcess::finished), this, &MainWindow::onExtractFinished);
   m_heclProc.start(m_heclPath, {"extract", "-y", "-g", "-o", m_path, imgPath},
                    QIODevice::ReadOnly | QIODevice::Unbuffered);
 
@@ -138,15 +139,15 @@ void MainWindow::onExtract() {
   disableOperations();
   m_ui->extractBtn->setText(QStringLiteral("Cancel"));
   m_ui->extractBtn->setEnabled(true);
-  disconnect(m_ui->extractBtn, SIGNAL(clicked()), nullptr, nullptr);
-  connect(m_ui->extractBtn, SIGNAL(clicked()), this, SLOT(doHECLTerminate()));
+  disconnect(m_ui->extractBtn, &QPushButton::clicked, nullptr, nullptr);
+  connect(m_ui->extractBtn, &QPushButton::clicked, this, &MainWindow::doHECLTerminate);
 }
 
 void MainWindow::onExtractFinished(int returnCode) {
   m_cursor.movePosition(QTextCursor::End);
   m_cursor.insertBlock();
-  disconnect(m_ui->extractBtn, SIGNAL(clicked()), nullptr, nullptr);
-  connect(m_ui->extractBtn, SIGNAL(clicked()), this, SLOT(onExtract()));
+  disconnect(m_ui->extractBtn, &QPushButton::clicked, nullptr, nullptr);
+  connect(m_ui->extractBtn, &QPushButton::clicked, this, &MainWindow::onExtract);
   checkDownloadedBinary();
 }
 
@@ -161,8 +162,8 @@ void MainWindow::onPackage() {
   env.insert("TERM", "xterm-color");
   env.insert("ConEmuANSI", "ON");
   m_heclProc.setProcessEnvironment(env);
-  disconnect(&m_heclProc, SIGNAL(finished(int)), nullptr, nullptr);
-  connect(&m_heclProc, SIGNAL(finished(int)), this, SLOT(onPackageFinished(int)));
+  disconnect(&m_heclProc, qOverload<int>(&QProcess::finished), nullptr, nullptr);
+  connect(&m_heclProc, qOverload<int>(&QProcess::finished), this, &MainWindow::onPackageFinished);
   m_heclProc.start(m_heclPath, {"package", "-y", "-g"}, QIODevice::ReadOnly | QIODevice::Unbuffered);
 
   m_ui->heclTabs->setCurrentIndex(0);
@@ -170,8 +171,8 @@ void MainWindow::onPackage() {
   disableOperations();
   m_ui->packageBtn->setText(QStringLiteral("Cancel"));
   m_ui->packageBtn->setEnabled(true);
-  disconnect(m_ui->packageBtn, SIGNAL(clicked()), nullptr, nullptr);
-  connect(m_ui->packageBtn, SIGNAL(clicked()), this, SLOT(doHECLTerminate()));
+  disconnect(m_ui->packageBtn, &QPushButton::clicked, nullptr, nullptr);
+  connect(m_ui->packageBtn, &QPushButton::clicked, this, &MainWindow::doHECLTerminate);
 
   QSize size = QWidget::size();
   if (size.width() < 1100)
@@ -182,8 +183,8 @@ void MainWindow::onPackage() {
 void MainWindow::onPackageFinished(int returnCode) {
   m_cursor.movePosition(QTextCursor::End);
   m_cursor.insertBlock();
-  disconnect(m_ui->packageBtn, SIGNAL(clicked()), nullptr, nullptr);
-  connect(m_ui->packageBtn, SIGNAL(clicked()), this, SLOT(onPackage()));
+  disconnect(m_ui->packageBtn, &QPushButton::clicked, nullptr, nullptr);
+  connect(m_ui->packageBtn, &QPushButton::clicked, this, &MainWindow::onPackage);
   checkDownloadedBinary();
 }
 
@@ -198,8 +199,8 @@ void MainWindow::onLaunch() {
   env.insert("TERM", "xterm-color");
   env.insert("ConEmuANSI", "ON");
   m_heclProc.setProcessEnvironment(env);
-  disconnect(&m_heclProc, SIGNAL(finished(int)), nullptr, nullptr);
-  connect(&m_heclProc, SIGNAL(finished(int)), this, SLOT(onLaunchFinished(int)));
+  disconnect(&m_heclProc, qOverload<int>(&QProcess::finished), nullptr, nullptr);
+  connect(&m_heclProc, qOverload<int>(&QProcess::finished), this, &MainWindow::onLaunchFinished);
   m_heclProc.start(m_urdePath, QStringList() << (m_path + "/out")
                                              << m_settings.value("urde_arguments").toStringList().join(' ').split(' '),
                    QIODevice::ReadOnly | QIODevice::Unbuffered);
@@ -449,9 +450,9 @@ void MainWindow::initSlots() {
     setTextTermFormatting(bytes);
   });
 
-  connect(m_ui->extractBtn, SIGNAL(clicked()), this, SLOT(onExtract()));
-  connect(m_ui->packageBtn, SIGNAL(clicked()), this, SLOT(onPackage()));
-  connect(m_ui->launchBtn, SIGNAL(clicked()), this, SLOT(onLaunch()));
+  connect(m_ui->extractBtn, &QPushButton::clicked, this, &MainWindow::onExtract);
+  connect(m_ui->packageBtn, &QPushButton::clicked, this, &MainWindow::onPackage);
+  connect(m_ui->launchBtn, &QPushButton::clicked, this, &MainWindow::onLaunch);
   m_ui->launchMenuBtn->setMenu(&m_launchMenu);
 
   connect(m_ui->browseBtn, &QPushButton::clicked, [=]() {
@@ -468,7 +469,7 @@ void MainWindow::initSlots() {
     setPath(dialog.selectedFiles().at(0));
   });
 
-  connect(m_ui->downloadButton, SIGNAL(clicked()), this, SLOT(onDownloadPressed()));
+  connect(m_ui->downloadButton, &QPushButton::clicked, this, &MainWindow::onDownloadPressed);
 }
 
 void MainWindow::setTextTermFormatting(const QString& text) {


### PR DESCRIPTION
Allows compile-time detection of incompatible signals/slots, as opposed to runtime errors, making the connections more type-safe.